### PR TITLE
Rename ambiguous isOptional function

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@ const isOptionalEmail = isEmail.or(isEmpty);
 
 await isOptionalEmail.check(''); // undefined
 await isOptionalEmail.check('test@gmail.com'); // undefined
-await isOptionalEmail.check('invalid mail'); // ['value must be an email', 'value is optional']
+await isOptionalEmail.check('invalid mail'); // ['value must be an email', 'value is not empty']
 ```
 
 You can validate object too

--- a/Readme.md
+++ b/Readme.md
@@ -39,14 +39,14 @@ await isEmailNotFromGMail.check('test@free.ff'); // undefined
 Or with or
 
 ```js
-const isOptional = validator((value) => {
+const isEmpty = validator((value) => {
     if (!!value) {
-        return Validation.Invalid([`value is optional`]);
+        return Validation.Invalid([`value is not empty`]);
     }
     return Validation.Valid(value);
 });
 
-const isOptionalEmail = isEmail.or(isOptional);
+const isOptionalEmail = isEmail.or(isEmpty);
 
 await isOptionalEmail.check(''); // undefined
 await isOptionalEmail.check('test@gmail.com'); // undefined


### PR DESCRIPTION
The `isOptional` function described in the Readme is, in fact, an `isEmpty` function.

because the result is
**Valid** when empty
**Invalid** when populated

It's just the mix between `isEmail` and `isEmpty` that makes an `isOptionalEmail` test